### PR TITLE
Amend DD-1061

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>dans-dropwizard-project</artifactId>
         <groupId>nl.knaw.dans.shared</groupId>
-        <version>9.2.0</version>
+        <version>9.3.0</version>
     </parent>
 
     <groupId>nl.knaw.dans</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,7 @@
         <dependency>
             <groupId>nl.knaw.dans</groupId>
             <artifactId>dans-dataverse-client-lib</artifactId>
+            <version>0.5.0</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/nl/knaw/dans/virusscan/core/service/DataverseApiService.java
+++ b/src/main/java/nl/knaw/dans/virusscan/core/service/DataverseApiService.java
@@ -27,7 +27,7 @@ public interface DataverseApiService {
 
     List<FileMeta> listFiles(String datasetId, String invocationId, String version) throws IOException, DataverseException;
 
-    InputStream getFile(int fileId) throws IOException, DataverseException;
+    InputStream getFile(int fileId, String invocationId) throws IOException, DataverseException;
 
     void completeWorkflow(String invocationId, String reason, String message) throws IOException, DataverseException;
 

--- a/src/main/java/nl/knaw/dans/virusscan/core/service/DataverseApiServiceImpl.java
+++ b/src/main/java/nl/knaw/dans/virusscan/core/service/DataverseApiServiceImpl.java
@@ -63,9 +63,9 @@ public class DataverseApiServiceImpl implements DataverseApiService {
     }
 
     @Override
-    public InputStream getFile(int fileId) throws IOException, DataverseException {
+    public InputStream getFile(int fileId, String invocationid) throws IOException, DataverseException {
         log.trace("Getting file with id {}", fileId);
-        return getDataverseClient().basicFileAccess(fileId).getFile().getEntity().getContent();
+        return getDataverseClient().basicFileAccess(fileId, invocationid).getFile().getEntity().getContent();
     }
 
     @Override

--- a/src/main/java/nl/knaw/dans/virusscan/core/task/DatasetScanTask.java
+++ b/src/main/java/nl/knaw/dans/virusscan/core/task/DatasetScanTask.java
@@ -63,7 +63,7 @@ public class DatasetScanTask implements Runnable {
 
         for (var file : files) {
             log.debug("Checking status for file {}", file.getDataFile().getFilename());
-            var fileInputStream = dataverseApiService.getFile(file.getDataFile().getId());
+            var fileInputStream = dataverseApiService.getFile(file.getDataFile().getId(), payload.getInvocationId());
             var viruses = virusScanner.scanForVirus(fileInputStream);
 
             if (viruses.size() > 0) {

--- a/src/test/java/nl/knaw/dans/virusscan/core/service/DatasetScanTaskTest.java
+++ b/src/test/java/nl/knaw/dans/virusscan/core/service/DatasetScanTaskTest.java
@@ -20,6 +20,7 @@ import nl.knaw.dans.virusscan.core.model.DatasetResumeTaskPayload;
 import nl.knaw.dans.virusscan.core.model.PrePublishWorkflowPayload;
 import nl.knaw.dans.virusscan.core.task.DatasetScanTask;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 
 import java.io.ByteArrayInputStream;
@@ -48,7 +49,7 @@ class DatasetScanTaskTest {
         Mockito.when(dataverseApiService.listFiles(Mockito.any(), Mockito.any(), Mockito.any()))
             .thenReturn(result.getData());
 
-        Mockito.when(dataverseApiService.getFile(Mockito.anyInt()))
+        Mockito.when(dataverseApiService.getFile(Mockito.anyInt(), Mockito.anyString()))
             .thenReturn(new ByteArrayInputStream("test".getBytes()));
 
         Mockito.when(virusScanner.scanForVirus(Mockito.any()))
@@ -83,7 +84,7 @@ class DatasetScanTaskTest {
         Mockito.when(dataverseApiService.listFiles(Mockito.any(), Mockito.any(), Mockito.any()))
             .thenReturn(data);
 
-        Mockito.when(dataverseApiService.getFile(Mockito.anyInt()))
+        Mockito.when(dataverseApiService.getFile(Mockito.anyInt(), Mockito.anyString()))
             .thenReturn(new ByteArrayInputStream("test".getBytes()));
 
         Mockito.when(virusScanner.scanForVirus(Mockito.any()))


### PR DESCRIPTION
# Description of changes
Add invocationId to all the calls to Dataverse. At the time of writing this, this will probably not work yet, because Dataverse doesn't implement authorization by invocationId everywhere it should.




# Related PRs
(Add links)
*

# Notify
@DANS-KNAW/dataversedans
